### PR TITLE
Handling empty queries & displaying the elastic endpoint

### DIFF
--- a/Glimpse.ElasticSearch/ElasticSearchTab.cs
+++ b/Glimpse.ElasticSearch/ElasticSearchTab.cs
@@ -19,7 +19,8 @@ namespace Glimpse.ElasticSearch
                 r.Cell(3).AlignRight();
                 r.Cell(4).AlignRight();
                 r.Cell(5).AlignRight();
-                r.Cell(6).WidthInPercent(60);
+                r.Cell(6).AlignRight();
+                r.Cell(7).WidthInPercent(60);
             }).Build();
 
         public override string Name
@@ -34,7 +35,7 @@ namespace Glimpse.ElasticSearch
 
         public override object GetData(ITabContext context)
         {
-            TabSection plugin = Plugin.Create("No", "Started", "Duration", "Method", "Index", "Document", "Query");
+            TabSection plugin = Plugin.Create("No", "Started", "Duration", "Method", "Index", "Document", "Endpoint", "Query");
 
             var requestContext = context.GetRequestContext<HttpContextBase>();
             List<RequestItem> items = RequestHandler.GetLogList(requestContext);
@@ -52,6 +53,7 @@ namespace Glimpse.ElasticSearch
                     .Column(item.Method)
                     .Column(item.Index)
                     .Column(item.Document)
+                    .Column(item.Endpoint)
                     .Column(item.Query);
             }
 

--- a/Glimpse.ElasticSearch/GlimpseHttpContext.cs
+++ b/Glimpse.ElasticSearch/GlimpseHttpContext.cs
@@ -20,7 +20,7 @@ namespace Glimpse.ElasticSearch
             HttpWebRequest request = base.CreateHttpWebRequest(uri, method, data, requestSpecificConfig);
             TimeSpan timeSpan = DateTime.Now.Subtract(tsStart);
 
-            RequestHandler.Add(tsStart, timeSpan, request.Method, uri, Encoding.UTF8.GetString(data));
+            RequestHandler.Add(tsStart, timeSpan, request.Method, uri, Encoding.UTF8.GetString(data ?? new byte[0]));
 
             return request;
         }

--- a/Glimpse.ElasticSearch/Properties/AssemblyInfo.cs
+++ b/Glimpse.ElasticSearch/Properties/AssemblyInfo.cs
@@ -35,5 +35,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/Glimpse.ElasticSearch/RequestHandler.cs
+++ b/Glimpse.ElasticSearch/RequestHandler.cs
@@ -33,6 +33,7 @@ namespace Glimpse.ElasticSearch
                 Method = method,
                 Index = GetSegment(uri, 1),
                 Document = GetSegment(uri, 2),
+                Endpoint = GetSegment(uri, 3),
                 Query = query
             };
 

--- a/Glimpse.ElasticSearch/RequestItem.cs
+++ b/Glimpse.ElasticSearch/RequestItem.cs
@@ -10,5 +10,6 @@ namespace Glimpse.ElasticSearch
         public DateTime Time = DateTime.Now;
         public string Document { get; set; }
         public string Index { get; set; }
+        public string Endpoint { get; set; }
     }
 }


### PR DESCRIPTION
Hello!

I've made two changes.
1. I updated GlimpseHttpContext.cs. An error was occurring when the query portion of a request to Elastic was empty. This resulted in the data parameter being null, which in turn caused the Encoding.UTF8.GetString to throw an exception.
2. I've added the an endpoint to the glimpse tab. This is especially useful when you're using an endpoint that doesn't require a query e.g. _count.

Let me know what you think.
