### PR TITLE
Fixed IndexOutOfRangeException when request URL only contains index

### DIFF
--- a/Glimpse.ElasticSearch.sln
+++ b/Glimpse.ElasticSearch.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Glimpse.ElasticSearch", "Glimpse.ElasticSearch\Glimpse.ElasticSearch.csproj", "{5A8CB7A1-9131-4CCE-BE3F-CC5E37EF9E46}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Glimpse.Elasticsearch.Tests", "Glimpse.Elasticsearch.Tests\Glimpse.Elasticsearch.Tests.csproj", "{00EFB5EA-F109-42C2-B9E5-2CCB807A81F6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{5A8CB7A1-9131-4CCE-BE3F-CC5E37EF9E46}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5A8CB7A1-9131-4CCE-BE3F-CC5E37EF9E46}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5A8CB7A1-9131-4CCE-BE3F-CC5E37EF9E46}.Release|Any CPU.Build.0 = Release|Any CPU
+		{00EFB5EA-F109-42C2-B9E5-2CCB807A81F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{00EFB5EA-F109-42C2-B9E5-2CCB807A81F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{00EFB5EA-F109-42C2-B9E5-2CCB807A81F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{00EFB5EA-F109-42C2-B9E5-2CCB807A81F6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Glimpse.ElasticSearch/Glimpse.ElasticSearch.csproj
+++ b/Glimpse.ElasticSearch/Glimpse.ElasticSearch.csproj
@@ -55,6 +55,7 @@
     <Compile Include="RequestItem.cs" />
     <Compile Include="ElasticSearchTab.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UriExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="package.nuspec" />

--- a/Glimpse.ElasticSearch/RequestHandler.cs
+++ b/Glimpse.ElasticSearch/RequestHandler.cs
@@ -31,9 +31,9 @@ namespace Glimpse.ElasticSearch
                 Time = time,
                 Duration = duration,
                 Method = method,
-                Index = uri.GetSegment(1),
-                Document = uri.GetSegment(2),
-                Endpoint = uri.GetSegment(3),
+                Index = uri.TryGetSegment(1),
+                Document = uri.TryGetSegment(2),
+                Endpoint = uri.TryGetSegment(3),
                 Query = query
             };
 

--- a/Glimpse.ElasticSearch/RequestHandler.cs
+++ b/Glimpse.ElasticSearch/RequestHandler.cs
@@ -31,9 +31,9 @@ namespace Glimpse.ElasticSearch
                 Time = time,
                 Duration = duration,
                 Method = method,
-                Index = GetSegment(uri, 1),
-                Document = GetSegment(uri, 2),
-                Endpoint = GetSegment(uri, 3),
+                Index = uri.GetSegment(1),
+                Document = uri.GetSegment(2),
+                Endpoint = uri.GetSegment(3),
                 Query = query
             };
 
@@ -46,11 +46,6 @@ namespace Glimpse.ElasticSearch
 
             var items = context.Items[Key] as List<RequestItem>;
             items.Add(requestItem);
-        }
-
-        private static string GetSegment(Uri uri, int index)
-        {
-            return uri.Segments.Length >= index ? uri.Segments[index].Trim('/') : null;
         }
     }
 }

--- a/Glimpse.ElasticSearch/UriExtensions.cs
+++ b/Glimpse.ElasticSearch/UriExtensions.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Glimpse.ElasticSearch
+{
+    public static class UriExtensions
+    {
+        public static string GetSegment(this Uri uri, int index)
+        {
+            return uri.Segments.Length >= index ? uri.Segments[index].Trim('/') : null;
+        }
+    }
+}

--- a/Glimpse.ElasticSearch/UriExtensions.cs
+++ b/Glimpse.ElasticSearch/UriExtensions.cs
@@ -6,7 +6,7 @@ namespace Glimpse.ElasticSearch
     {
         public static string GetSegment(this Uri uri, int index)
         {
-            return uri.Segments.Length >= index ? uri.Segments[index].Trim('/') : null;
+            return uri.Segments.Length > index ? uri.Segments[index].Trim('/') : null;
         }
     }
 }

--- a/Glimpse.ElasticSearch/UriExtensions.cs
+++ b/Glimpse.ElasticSearch/UriExtensions.cs
@@ -4,7 +4,7 @@ namespace Glimpse.ElasticSearch
 {
     public static class UriExtensions
     {
-        public static string GetSegment(this Uri uri, int index)
+        public static string TryGetSegment(this Uri uri, int index)
         {
             return uri.Segments.Length > index ? uri.Segments[index].Trim('/') : null;
         }

--- a/Glimpse.ElasticSearch/package.nuspec
+++ b/Glimpse.ElasticSearch/package.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Glimpse.ElasticSearch</id>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <title>Glimpse for ElasticSearch</title>
     <authors>Onuralp Taner</authors>
     <owners>onuralp</owners>

--- a/Glimpse.Elasticsearch.Tests/Glimpse.Elasticsearch.Tests.csproj
+++ b/Glimpse.Elasticsearch.Tests/Glimpse.Elasticsearch.Tests.csproj
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{00EFB5EA-F109-42C2-B9E5-2CCB807A81F6}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Glimpse.Elasticsearch.Tests</RootNamespace>
+    <AssemblyName>Glimpse.Elasticsearch.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.2.0\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="UriExtensionsTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Glimpse.ElasticSearch\Glimpse.ElasticSearch.csproj">
+      <Project>{5A8CB7A1-9131-4CCE-BE3F-CC5E37EF9E46}</Project>
+      <Name>Glimpse.ElasticSearch</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Glimpse.Elasticsearch.Tests/Properties/AssemblyInfo.cs
+++ b/Glimpse.Elasticsearch.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Glimpse.Elasticsearch.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Glimpse.Elasticsearch.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("00efb5ea-f109-42c2-b9e5-2ccb807a81f6")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Glimpse.Elasticsearch.Tests/UriExtensionsTests.cs
+++ b/Glimpse.Elasticsearch.Tests/UriExtensionsTests.cs
@@ -12,7 +12,7 @@ namespace Glimpse.Elasticsearch.Tests
         {
             var uri = new Uri("http://test-host:9200/index");
 
-            Assert.That(uri.GetSegment(2), Is.Null);
+            Assert.That(uri.TryGetSegment(2), Is.Null);
         }
 
         [Test]
@@ -20,7 +20,7 @@ namespace Glimpse.Elasticsearch.Tests
         {
             var uri = new Uri("http://test-host:9200/index");
 
-            Assert.That(uri.GetSegment(1), Is.EqualTo("index"));
+            Assert.That(uri.TryGetSegment(1), Is.EqualTo("index"));
         }
     }
 }

--- a/Glimpse.Elasticsearch.Tests/UriExtensionsTests.cs
+++ b/Glimpse.Elasticsearch.Tests/UriExtensionsTests.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Glimpse.ElasticSearch;
+using NUnit.Framework;
+
+namespace Glimpse.Elasticsearch.Tests
+{
+    [TestFixture]
+    public class UriExtensionsTests
+    {
+        [Test]
+        public void GetSegment_ForIndexEqualToSegmentsCount_ShouldReturnNull()
+        {
+            var uri = new Uri("http://test-host:9200/index");
+
+            Assert.That(uri.GetSegment(2), Is.Null);
+        }
+
+        [Test]
+        public void GetSegment_ForIndexLessThanSegmentsCount_ShouldReturnSegmentValue()
+        {
+            var uri = new Uri("http://test-host:9200/index");
+
+            Assert.That(uri.GetSegment(1), Is.EqualTo("index"));
+        }
+    }
+}

--- a/Glimpse.Elasticsearch.Tests/packages.config
+++ b/Glimpse.Elasticsearch.Tests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="3.2.0" targetFramework="net452" />
+</packages>


### PR DESCRIPTION
The check in `RequestHandler.GetSegment` method was inaccurate, which led to `IndexOutOfRangeException` for urls that do not contain four segments (for example, `http://test-host:9200/index`).

I've fixed the check, made `GetSegment` an extension method, added tests for that and renamed `GetSegment` to `TryGetSegment` to emphasize that it wouldn't ever throw.
